### PR TITLE
Set consistent label capitalization on home screen

### DIFF
--- a/src/locales/source/en.json
+++ b/src/locales/source/en.json
@@ -75,7 +75,7 @@
   },
   "home": {
     "link": "Dashboard",
-    "title": "Printer status"
+    "title": "Printer Status"
   },
   "logs": {
     "empty-file": "Log file is empty!",


### PR DESCRIPTION
Updated capitalization of "Printer status" to be consistent with other labels on the home screen.