### PR TITLE
Fix an error in webpack.config.js when PRINTER_NAME is not set

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -21,9 +21,11 @@ function withDefault(value, defaultValue) {
 module.exports = (env, args) => {
   const buildLocales = env.locales;
 
+  var printerName = env["PRINTER_NAME"] || DEFAULT_NAME;
+
   var config = {
-    PRINTER_NAME: env["PRINTER_NAME"] || DEFAULT_NAME,
-    PRINTER_CODE: env["PRINTER_NAME"].split(" ").slice(-1)[0].toLowerCase(),
+    PRINTER_NAME: printerName,
+    PRINTER_CODE: printerName.split(" ").slice(-1)[0].toLowerCase(),
     PRINTER_TYPE: env["PRINTER_TYPE"] || "fdm", // "fdm" | "sla"
     PROJECT_EXTENSIONS: env["PROJECT_EXTENSIONS"] || [".gcode"],
 


### PR DESCRIPTION
When trying to run the project without explicitly setting the printer name via `PRINTER_NAME` environment variable, I encountered following error:

```
$ npm run start
                                                 
> prusalink@3.10.1 start                       
> webpack serve --env dev
                                                 
[webpack-cli] TypeError: Cannot read properties of undefined (reading 'split')
    at module.exports (/Users/ilya/projects/Prusa-Link-Web/webpack.config.js:26:39)
    ...
```

The culprit is that the default printer name is not used when setting `PRINTER_CODE` value.
This PR is a trivial fix for that.