### PR TITLE
Fix preview update when changed from another window

### DIFF
--- a/src/printer/components/progressImage.js
+++ b/src/printer/components/progressImage.js
@@ -12,6 +12,10 @@ export function renderProgressImg(root, src, progress = 0) {
   if (!root)
     return;
 
+  while (root.firstChild) {
+    root.removeChild(root.firstChild)
+  }
+
   const wrapper = document.createElement("div");
   wrapper.className = "progress-img";
 


### PR DESCRIPTION
Solves two issues:
- Adds force redraw of img component when path changes, so it will be rerendered
- Fixes update of the preview that is inside of a progress indicator. 