### PR TITLE
Switch to LinkState as the main source of truth for start printing

### DIFF
--- a/src/printer/components/files.js
+++ b/src/printer/components/files.js
@@ -19,6 +19,7 @@ import * as job from "./job";
 import { initKebabMenu } from "./kebabMenu.js";
 import { setEnabled } from "../../helpers/element.js";
 import storage from "./storage.js";
+import { LinkState, OperationalStates } from "../../state.js";
 
 let lastData = null;
 let intersectionObserver = null;
@@ -110,10 +111,10 @@ const updateData = () => {
  * @param {object} context
  */
 export const update = (context) => {
-  const flags = context.printer.state.flags;
+  const linkState = LinkState.fromApi(context.printer.state);
   updateData();
   job.update(context, true);
-  upload.update(flags.ready && flags.operational);
+  upload.update(OperationalStates.includes(linkState));
 };
 
 function initUpload(context) {

--- a/src/printer/components/job.js
+++ b/src/printer/components/job.js
@@ -14,7 +14,7 @@ import { updateProgressBar } from "./progressBar";
 import { translate } from "../../locale_provider";
 import changeExposureTimesQuestion from "../sla/exposure";
 import { resinRefill } from "../sla/refill";
-import { LinkState } from "../../state";
+import { LinkState, OperationalStates } from "../../state";
 
 let metadata = getDefaultMetadata();
 let filePreviewMetadata = getDefaultFilePreviewMetadata();
@@ -238,8 +238,9 @@ function updateComponent(context, isFilePreview) {
     if (process.env.PRINTER_TYPE === "sla") {
       setupRefill(state.text);
     }
+    const linkState = LinkState.fromApi(state);
+    const isJobPreview = OperationalStates.includes(linkState);
 
-    const isJobPreview = state.flags.ready && state.flags.operational;
     setupProperties(isJobPreview);
 
     updateProperties("job", jobResult);
@@ -437,7 +438,8 @@ function setupButtons(context, jobResult, file, isFilePreview) {
 function setupCancelButton(state, isFilePreview) {
   const btnStop = document.querySelector("#job #stop");
   const btnClose = document.querySelector("#job-close");
-  const isJobPreview = state.flags.ready && state.flags.operational;
+  const linkState = LinkState.fromApi(state);
+  const isJobPreview = OperationalStates.includes(linkState);
 
   setEnabled(btnStop, state.flags.printing && !state.flags.cancelling)
 
@@ -458,8 +460,9 @@ function setupCancelButton(state, isFilePreview) {
 }
 
 function setupStartButton(state, fileUrl, isFilePreview) {
+  const linkState = LinkState.fromApi(state);
   const btn = document.querySelector("#job #start");
-  const canPrint = state.flags.ready && state.flags.operational;
+  const canPrint = OperationalStates.includes(linkState);
 
   if (btn) {
     const linkState = LinkState.fromApi(state);

--- a/src/printer/fdm/dashboard.js
+++ b/src/printer/fdm/dashboard.js
@@ -6,6 +6,7 @@ import * as graph from "../components/temperature_graph";
 import upload from "../components/upload";
 import { translate } from "../../locale_provider";
 import * as job from "../components/job";
+import { LinkState, OperationalStates } from "../../state";
 
 const load = (context) => {
   translate("home.link", { query: "#title-status-label" });
@@ -15,9 +16,9 @@ const load = (context) => {
 };
 
 const update = (context) => {
-  const flags = context.printer.state.flags;
+  const linkState = LinkState.fromApi(context.printer.state);
   job.update(context);
-  upload.update(flags.ready && flags.operational);
+  upload.update(OperationalStates.includes(linkState));
 };
 
 export default { load, update };

--- a/src/state.js
+++ b/src/state.js
@@ -19,6 +19,12 @@ export const LinkState = {
     },
 };
 
+export const OperationalStates = [
+    LinkState.IDLE,
+    LinkState.READY,
+    LinkState.FINISHED
+];
+
 // Preferred way
 const fromLinkState = (linkState) => {
     switch (linkState.toUpperCase()) {


### PR DESCRIPTION
Instead of flags, use link state as a source of truth for start printing condition. LinkState object is built in the way, that it falls back to `ready && `operational` in case if `link_state` property was not provided.