### PR TITLE
Add state control for start-after-upload checkboxes

### DIFF
--- a/src/printer/components/files.js
+++ b/src/printer/components/files.js
@@ -115,7 +115,7 @@ export const update = (context) => {
   const linkState = LinkState.fromApi(context.printer.state);
   updateData();
   job.update(context, true);
-  upload.update(OperationalStates.includes(linkState));
+  upload.update(linkState);
 };
 
 function initUpload(context) {

--- a/src/printer/components/upload/confirm.js
+++ b/src/printer/components/upload/confirm.js
@@ -1,5 +1,6 @@
 import { modal } from "../modal";
 import { setDisabled } from "../../../helpers/element";
+import { LinkState } from "../../../state";
 
 const createConfirmUpload = (close, checkbox) => {
     const template = document.getElementById("modal-confirm");
@@ -23,7 +24,7 @@ const createConfirmUpload = (close, checkbox) => {
 
 export const attachConfirmModalToCheckbox = (checkbox) => {
     checkbox.addEventListener("change", (event) => {       
-        if (!checkbox.checked) {
+        if (!checkbox.checked || checkbox.getAttribute("data-link-state") === LinkState.READY) {
             return;
         }
         modal((close) => createConfirmUpload(close, checkbox), {

--- a/src/printer/components/upload/direct.js
+++ b/src/printer/components/upload/direct.js
@@ -8,6 +8,7 @@ import { setDisabled } from "../../../helpers/element";
 import { translate } from "../../../locale_provider";
 import uploadRequest from "../../../helpers/upload_request";
 import { attachConfirmModalToCheckbox } from "./confirm";
+import { LinkState, OperationalStates } from "../../../state";
 
 let isUploading = false;
 let progress = 0;
@@ -21,9 +22,11 @@ function init(origin, path, fileExtensions) {
   }
 }
 
-function update(canStartPrinting) {
+function update(linkState) {
+  const canStartPrinting = OperationalStates.includes(linkState);
   const startPrintCheckbox = document.querySelector("#upld-direct-start-pt");
   if (startPrintCheckbox) {
+    startPrintCheckbox.setAttribute("data-link-state", linkState);
     if (!canStartPrinting) {
       startPrintCheckbox.checked = false;
     }

--- a/src/printer/components/upload/index.js
+++ b/src/printer/components/upload/index.js
@@ -21,9 +21,9 @@ function hide(isHidden) {
   setHidden(document.getElementById("upld"), isHidden);
 }
 
-function update(canStartPrinting = false) {
-  direct?.update(canStartPrinting);
-  remote?.update(canStartPrinting);
+function update(linkState) {
+  direct?.update(linkState);
+  remote?.update(linkState);
   updateTabs();
 }
 

--- a/src/printer/components/upload/remote.js
+++ b/src/printer/components/upload/remote.js
@@ -10,6 +10,7 @@ import { translate } from "../../../locale_provider";
 import { updateProgressBar } from "../progressBar";
 import { attachConfirmModalToCheckbox } from "./confirm";
 import updateProperties from "../updateProperties";
+import { OperationalStates } from "../../../state";
 
 let isUploading = false;
 let lastResult = null;
@@ -50,9 +51,11 @@ function init(origin, path) {
   update();
 }
 
-function update(canStartPrinting) {
+function update(linkState) {
+  const canStartPrinting = OperationalStates.includes(linkState);
   const startPrintCheckbox = document.querySelector("#upld-remote-start-pt");
   if (startPrintCheckbox) {
+    startPrintCheckbox.setAttribute("data-link-state", linkState);
     if (!canStartPrinting) {
       startPrintCheckbox.checked = false;
     }

--- a/src/printer/fdm/dashboard.js
+++ b/src/printer/fdm/dashboard.js
@@ -18,7 +18,7 @@ const load = (context) => {
 const update = (context) => {
   const linkState = LinkState.fromApi(context.printer.state);
   job.update(context);
-  upload.update(OperationalStates.includes(linkState));
+  upload.update(linkState);
 };
 
 export default { load, update };

--- a/src/printer/sla/dashboard.js
+++ b/src/printer/sla/dashboard.js
@@ -6,6 +6,7 @@ import * as graph from "../components/temperature_graph";
 import upload from "../components/upload";
 import { translate } from "../../locale_provider";
 import * as job from "../components/job";
+import { LinkState } from "../../state";
 
 const load = (context) => {
   translate("home.link", { query: "#title-status-label" });
@@ -15,9 +16,9 @@ const load = (context) => {
 };
 
 const update = (context) => {
-  const flags = context.printer.state.flags;
+  const linkState = LinkState.fromApi(context.printer.state);
   job.update(context);
-  upload.update(flags.ready && flags.operational);
+  upload.update(linkState);
 };
 
 export default { load, update };


### PR DESCRIPTION
Do not show printer control dialog if printer is in READY state.