### PR TITLE
Make API key input a password field

### DIFF
--- a/templates/components/modal/apiKey.html
+++ b/templates/components/modal/apiKey.html
@@ -15,7 +15,7 @@
         You can find it in Settings -> Network -> Login credentials.
       </span>
     </p>
-    <input id="apiKey" class="txt-md txt-grey" type="text" autofocus />
+    <input id="apiKey" class="txt-md txt-grey" type="password" autofocus />
     <button class="yes" id="login">
       <img src="{{ pre.countOrRenderAssets('yes_color.svg') | safe }}" />
       <p data-label="btn.login">Login</p>


### PR DESCRIPTION
Allows for storage of API key in password managers, fixes part of #222 