### PR TITLE
Track command execution status by printer state change

### DIFF
--- a/src/printer/components/jobActions.js
+++ b/src/printer/components/jobActions.js
@@ -63,7 +63,7 @@ export const pauseJob = () => {
 /**
  * Cancel job modal.
  */
- const createCancelJobModal = (close) => {
+ const createCancelJobModal = (close, onConfirm) => {
   const template = document.getElementById("modal-question");
   const node = document.importNode(template.content, true);
   const label = node.getElementById("modal-question-label");
@@ -73,6 +73,7 @@ export const pauseJob = () => {
 
   yesButton.addEventListener("click", (event) => {
     event.preventDefault();
+    onConfirm && onConfirm();
     setDisabled(yesButton, true);
     setDisabled(noButton, true);
     getJson("/api/job", {
@@ -94,8 +95,8 @@ export const pauseJob = () => {
 /**
  * Shows modal, then stops printing.
  */
- export const cancelJob = () => {
-  modal((close) => createCancelJobModal(close), {
+ export const cancelJob = (onConfirm) => {
+  modal((close) => createCancelJobModal(close, onConfirm), {
     timeout: 0,
     closeOutside: false,
   });

--- a/templates/components/job/buttons.html
+++ b/templates/components/job/buttons.html
@@ -52,13 +52,6 @@
       class: 'action',
       hidden: true
     },
-    'pausing': {
-      text: 'pausing',
-      label: 'prop.st-pausing',
-      class: 'action',
-      disabled: true,
-      hidden: true
-    },
     'resume': {
       text: 'resume',
       label: 'btn.resume-pt',


### PR DESCRIPTION
According to feedback from **CONNECT-1641**:

- Stop/Pause/Resume buttons trigger special kind of tracking and disable themselves until printer's status change
- Printer does not have `Pausing`, `Cancelling` or `Resuming` status, so in the sidebar there is still the status that is provided by printer
- But from UX perspective, it is visible, that printer accepted the command. In theory we can show some extra label ( `Pausing`, `Cancelling` or `Resuming`) somewhere, if necessary