### PR TITLE
Fix dev server configuration

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -175,10 +175,10 @@ module.exports = (env, args) => {
             "/": BACKEND_URL
           }
         }: {
-          contentBase: path.join(__dirname, "dist"),
+          static: path.join(__dirname, "dist"),
           compress: true,
-          after: function (app, server, compiler) {
-            devServer(app, config);
+          onAfterSetupMiddleware: function (server) {
+            devServer(server.app, config);
             preprocessing.startWatcher(server);
           },
         }


### PR DESCRIPTION
WebPack was upgraded before, but configuration of dev server was not. Due to noone use it. API of the dev server should be updated separately.

Closes #329