### PR TITLE
Fix job starting from the preview

### DIFF
--- a/src/printer/components/job.js
+++ b/src/printer/components/job.js
@@ -452,9 +452,9 @@ function setupButtons(context, jobResult, file, isFilePreview) {
     setupCancelButton(state, isFilePreview);
 
     if (file.ready) {
-      const fileUrl = file?.refs?.resource || joinPaths("api/files", file.data.origin, file.data.path);
-      setupStartButton(state, fileUrl, isFilePreview);
-      setupDeleteButton(jobState, file.data, isFilePreview);
+      const resource = joinPaths("api/v1/files", metadata.path);
+      setupStartButton(state, resource, isFilePreview);
+      setupDeleteButton(jobState, file, resource, isFilePreview);
       setupDownloadButton(jobState, file.data, isFilePreview);
     }
 


### PR DESCRIPTION
- Start a file printing from the file browser
- Stop printing. The job will be still active on printer side, so even after page reload you will see the file on the dashboard
- Start printing of the file from dashboard. It should successfully start
- Delete button should also work