### PR TITLE
Wrap filename with 'anywhere' behavior

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -1040,6 +1040,7 @@ button:disabled {
   margin-top: 1rem;
 }
 #job .file-name {
+  overflow-wrap: anywhere;
   margin-bottom: 20px;
 }
 #job .progress {


### PR DESCRIPTION
Rather than having the filename run on for one line even when it is particularly long (as is commonly the case with gcode filenames). Have the filename wrap into another line. This works on both desktop and mobile layouts with a big improvement to the look of the webpage on mobile.

Before:
![Prusalink_no_wrap](https://github.com/prusa3d/Prusa-Link-Web/assets/11963090/6d36ee2a-c9e7-41b0-9c2a-026a1f60405e)

After:
![192 168 86 95_(iPhone 12 Pro)](https://github.com/prusa3d/Prusa-Link-Web/assets/11963090/e0398e9e-33c3-428e-875e-5162a75485e8)
