### PR TITLE
Add .bgcode to FILE_EXTENSIONS

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,7 +28,7 @@ module.exports = (env, args) => {
     PRINTER_NAME: printerName,
     PRINTER_CODE: printerName.split(" ").slice(-1)[0].toLowerCase(),
     PRINTER_TYPE: env["PRINTER_TYPE"] || "fdm", // "fdm" | "sla"
-    FILE_EXTENSIONS: env["FILE_EXTENSIONS"] || [".gcode"],
+    FILE_EXTENSIONS: env["FILE_EXTENSIONS"] || [".gcode", ".bgcode"],
 
     APP_NAME: env["APP_NAME"] || "PrusaLink",
     APP_TITLE: env["APP_TITLE"] || env["PRINTER_NAME"] || DEFAULT_NAME,


### PR DESCRIPTION
This allows easier uploading of .bgcode files.
Currently the browser upload UI will only allow to upload .gcode files at first.
You have to manually choose `Format all files` in chrome.

<img width="1099" alt="image" src="https://github.com/prusa3d/Prusa-Link-Web/assets/11361566/0dabbaef-032a-4139-a59d-b27ee083ada4">
<img width="1101" alt="image" src="https://github.com/prusa3d/Prusa-Link-Web/assets/11361566/57267cbd-1972-4779-9fa5-f939a7ddaa40">

This was reported in issue https://github.com/prusa3d/Prusa-Link-Web/issues/455 