### PR TITLE
fix(spec): correct typos

### DIFF
--- a/spec/openapi-legacy.yaml
+++ b/spec/openapi-legacy.yaml
@@ -18,7 +18,7 @@ security:
 paths:
   /api/version:
     get:
-      summary: version informations
+      summary: version information
       parameters:
         - in: query
           name: system
@@ -53,7 +53,7 @@ paths:
                     example: "prusa-sl1"
                   firmware:
                     type: string
-                    description: "Firmaware version"
+                    description: "Firmware version"
                     example: "3.10.0"
                   sdk:
                     type: string
@@ -168,7 +168,7 @@ paths:
   # platform dependent
   /api/printerprofiles:
     get:
-      summary: Retrive a mock of octoprinter printer profile
+      summary: Retrieve a mock of octoprinter printer profile
       responses:
         200:
           description: OK
@@ -184,7 +184,7 @@ paths:
 
   /api/printer:
     get:
-      summary: Retrive the current printer state
+      summary: Retrieve the current printer state
       parameters:
         - in: query
           name: exclude
@@ -419,7 +419,7 @@ paths:
   #    sends Content-Location header with URL to <PCL IP>/error (in the future it may send URL to hlep.prusa3d.com)
   /api/printer/error:
     get:
-      summary: Retrive the error number and text. Not compatible with OctoPrint.
+      summary: Retrieve the error number and text. Not compatible with OctoPrint.
       responses:
         200:
           description: Custom endpoint to get error details. Client can see if printer is in error state by polling /api/printer
@@ -1643,7 +1643,7 @@ components:
         offset:
           type: number
           nullable: true
-          description: Currenntly configured temperature offset to apply.
+          description: Currently configured temperature offset to apply.
       example:
         actual: 22.5
         target: 50.0
@@ -2268,11 +2268,11 @@ components:
           example: "10108"
         title:
           type: string
-          description: Prusa error text string with prefiled variable macros.
+          description: Prusa error text string with prefilled variable macros.
           example: "RESIN TOO LOW"
         text:
           type: string
-          description: Prusa error text string with prefiled variable macros.
+          description: Prusa error text string with prefilled variable macros.
           example: "Measured resin volume 22.4 ml is lower than required for this print. Refill the tank and restart the print."
         url:
           type: string

--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -16,7 +16,7 @@ security:
 paths:
   /api/version:
     get:
-      summary: api version informations
+      summary: api version information
       responses:
         200:
           description: OK
@@ -29,7 +29,7 @@ paths:
 
   /api/v1/info:
     get:
-      summary: printer informations
+      summary: printer information
       responses:
         200:
           description: OK
@@ -1011,7 +1011,7 @@ components:
               example: 215
         brim_width:
           type: integer
-          description: Milimeters
+          description: Millimeters
           example: 0
         estimated printing time (normal mode):
           type: string
@@ -1073,7 +1073,7 @@ components:
           example: 5
         layer_height:
           type: number
-          description: Milimeters
+          description: Millimeters
           example: 0.3
         material_name:
           type: string
@@ -1100,13 +1100,13 @@ components:
           example: 1
         nozzle_diameter:
           type: number
-          description: Milimeters
+          description: Millimeters
           example: 0.4
         nozzle_diameter per tool:
           type: array
           items:
               type: number
-              description: Milimeters
+              description: Millimeters
               example: 0.4
         normal_percent_present:
           type: boolean
@@ -1409,7 +1409,7 @@ components:
           example: 42.25
         transferred:
           type: integer
-          description: Transfered data in bytes
+          description: Transferred data in bytes
           example: 3276800
         time_remaining:
           type: integer
@@ -1521,11 +1521,11 @@ components:
           example: "10108"
         title:
           type: string
-          description: Prusa error text string with prefiled variable macros.
+          description: Prusa error text string with prefilled variable macros.
           example: "RESIN TOO LOW"
         text:
           type: string
-          description: Prusa error text string with prefiled variable macros.
+          description: Prusa error text string with prefilled variable macros.
           example: "Measured resin volume 22.4 ml is lower than required for this print. Refill the tank and restart the print."
         url:
           type: string


### PR DESCRIPTION
The API specification contains some typos.