### PR TITLE
mini: Sort by name by default

### DIFF
--- a/config.mini.js
+++ b/config.mini.js
@@ -21,7 +21,7 @@ module.exports = (env, args) => {
         WITH_PREVIEW_LAZY_QUEUE: true,
         WITH_DOWNLOAD_BUTTON: true,
         WITH_API_KEY_AUTH: false,
-        WITH_NAME_SORTING_ONLY: false,
+        WITH_NAME_SORTING_DEFAULT: true,
         WITH_TELEMETRY_NOZZLE_DIAMETER: true,
         WITH_V1_API: true,
         ...env,

--- a/src/printer/components/files.js
+++ b/src/printer/components/files.js
@@ -31,9 +31,7 @@ const FILE_TYPE = {
   "FILE": "FILE"
 };
 
-const SORT_FIELDS = process.env["WITH_NAME_SORTING_ONLY"]
-  ? ["name"]
-  : ["name", "date", "size"];
+const SORT_FIELDS = ["name", "date", "size"];
 
 let intersectionObserver = null;
 let previewLazyQueue = [];
@@ -49,8 +47,8 @@ const metadata = {
   files: [],
   eTag: null,
   sort: {
-    field: process.env["WITH_NAME_SORTING_ONLY"] ? "name" : "date",
-    order: process.env["WITH_NAME_SORTING_ONLY"] ? "asc" : "desc",
+    field: process.env["WITH_NAME_SORTING_DEFAULT"] ? "name" : "date",
+    order: process.env["WITH_NAME_SORTING_DEFAULT"] ? "asc" : "desc",
   },
 };
 
@@ -450,14 +448,12 @@ function createCurrent() {
   component.querySelector("#sort-by-name p").innerText = translate(
     "sort.by-name"
   );
-  if (!process.env["WITH_NAME_SORTING_ONLY"]) {
-    component.querySelector("#sort-by-date p").innerText = translate(
-      "sort.by-date"
-    );
-    component.querySelector("#sort-by-size p").innerText = translate(
-      "sort.by-size"
-    );
-  }
+  component.querySelector("#sort-by-date p").innerText = translate(
+    "sort.by-date"
+  );
+  component.querySelector("#sort-by-size p").innerText = translate(
+    "sort.by-size"
+  );
 
   component
     .querySelector(`#sort-by-${metadata.sort.field}`)

--- a/templates/components/node/current_folder.html
+++ b/templates/components/node/current_folder.html
@@ -11,15 +11,9 @@
   }
 %}
 
-{% if env.WITH_NAME_SORTING_ONLY %}
-{%
-  set sort_by = ['name']
-%}
-{% else %}
 {%
   set sort_by = ['name', 'date', 'size']
 %}
-{% endif %}
 
 <template id="node-current">
   <div class="line-y node-current">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -62,7 +62,7 @@ module.exports = (env, args) => {
     WITH_API_KEY_AUTH: withDefault(env["WITH_API_KEY_AUTH"], false),
     WITH_CAMERAS: withDefault(env["WITH_CAMERAS"], false),
     WITH_API_KEY_SETTING: withDefault(env["WITH_API_KEY_SETTING"], false),
-    WITH_NAME_SORTING_ONLY: withDefault(env["WITH_NAME_SORTING_ONLY"], false),
+    WITH_NAME_SORTING_DEFAULT: withDefault(env["WITH_NAME_SORTING_DEFAULT"], false),
     WITH_SYSTEM_UPDATES: withDefault(env["WITH_SYSTEM_UPDATES"], false),
 
     WITH_SYSTEM_VERSION: withDefault(env["WITH_SYSTEM_VERSION"], false),


### PR DESCRIPTION
We allowed sorting by date or size recently, but wanted to preserve the original behaviour of sorting by name.